### PR TITLE
Конфигурационные параметры ReportPortal перенесены в appsettings

### DIFF
--- a/src/Molder.ReportPortal/Helper/ConfigOptionsFactory.cs
+++ b/src/Molder.ReportPortal/Helper/ConfigOptionsFactory.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Molder.ReportPortal.Infrastructures;
+using Molder.ReportPortal.Models.Settings;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace Molder.ReportPortal.Helper
+{
+    public class ConfigOptionsFactory
+    {
+        public static IOptions<Settings> Create(IConfiguration configuration)
+        {
+            var blc = configuration.GetSection(Constants.CONFIG_BLOCK).GetSection(Constants.SETTINGS_BLOCK);
+            var settings = blc.Get<Settings>();
+            return Options.Create(settings);
+        }
+    }
+}

--- a/src/Molder.ReportPortal/Hooks/Hooks.cs
+++ b/src/Molder.ReportPortal/Hooks/Hooks.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Molder.Helpers;
+using Molder.Models.Configuration;
+using Molder.ReportPortal.Helper;
+using Molder.ReportPortal.Infrastructures;
+using Molder.ReportPortal.Models.Settings;
+using ReportPortal.Client;
+using ReportPortal.Client.Abstractions.Models;
+using ReportPortal.SpecFlowPlugin;
+using ReportPortal.SpecFlowPlugin.EventArguments;
+using System;
+using TechTalk.SpecFlow;
+
+namespace Molder.ReportPortal.Hooks
+{
+    [Binding]
+    class Hooks : Steps
+    {
+        [BeforeTestRun(Order = -9000000)]
+
+        public static void InitializeConfiguration()
+        {
+            var settings = ConfigOptionsFactory.Create(ConfigurationExtension.Instance.Configuration);
+
+            if (settings.Value is null)
+            {
+                Log.Logger().LogInformation($@"appsettings is not contains {Constants.CONFIG_BLOCK} block.");
+            }
+            else
+            {
+                Log.Logger().LogInformation($@"appsettings contains {Constants.CONFIG_BLOCK} block. Settings selected.");
+                ReportPortalSettings.Settings = settings.Value;
+                AddCustomHandlers();
+            }
+        }
+
+        private static void AddCustomHandlers()
+        {
+            if (ReportPortalSettings.Settings.Enabled)
+            {
+                ReportPortalAddin.Initializing += ReportPortalAddin_Initializing;
+                ReportPortalAddin.BeforeRunStarted += ReportPortalAddin_BeforeRunStarted;
+            } 
+        }
+
+        /// <summary>
+        /// set up RP server properties
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private static void ReportPortalAddin_Initializing(object sender, InitializingEventArgs e)
+        {
+            e.Service = new Service(
+                new Uri(ReportPortalSettings.Settings.ServerSettings.Url),
+                ReportPortalSettings.Settings.ServerSettings.Project,
+                ReportPortalSettings.Settings.ServerSettings.Token);
+        }
+
+        /// <summary>
+        /// set up RP launch properties
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private static void ReportPortalAddin_BeforeRunStarted(object sender, RunStartedEventArgs e)
+        {
+            e.StartLaunchRequest.Description = ReportPortalSettings.Settings.LaunchSettings.Description;
+            e.StartLaunchRequest.Name = ReportPortalSettings.Settings.LaunchSettings.Name;
+            e.StartLaunchRequest.IsRerun = ReportPortalSettings.Settings.LaunchSettings.IsRerun;
+            e.StartLaunchRequest.RerunOfLaunchUuid = ReportPortalSettings.Settings.LaunchSettings.RerunOfLaunchUuid;
+            e.StartLaunchRequest.StartTime = ReportPortalSettings.Settings.LaunchSettings.StartTime;
+
+#if DEBUG
+            e.StartLaunchRequest.Mode = LaunchMode.Debug;
+#else
+            e.StartLaunchRequest.Mode = LaunchMode.Default;
+#endif
+            ReportPortalSettings.Settings.LaunchSettings.Tags.ForEach(t =>
+            e.StartLaunchRequest.Attributes.Add(new ItemAttribute { Value = t }));
+        }
+
+        
+    }
+}

--- a/src/Molder.ReportPortal/Infrastructures/Constants.cs
+++ b/src/Molder.ReportPortal/Infrastructures/Constants.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Molder.ReportPortal.Infrastructures
+{
+    [ExcludeFromCodeCoverage]
+    public static class Constants
+    {
+        #region Configuration constants
+        public const string CONFIG_BLOCK = "Molder.ReportPortal";
+        public const string SETTINGS_BLOCK = "Settings";
+        #endregion
+
+        public const bool ENABLE_RP_REPORT = false;
+
+        public const string DEFAULT_RP_CONFIG = "{\"$schema\": \"https://raw.githubusercontent.com/reportportal/agent-net-specflow/master/ReportPortal.SpecFlowPlugin/ReportPortal.config.schema\",\"enabled\":true,\"server\":{\"url\":\"\",\"project\":\"\",\"authentication\":{\"uuid\":\"\"}}}";
+    }
+}

--- a/src/Molder.ReportPortal/Infrastructures/Constants.cs
+++ b/src/Molder.ReportPortal/Infrastructures/Constants.cs
@@ -11,7 +11,5 @@ namespace Molder.ReportPortal.Infrastructures
         #endregion
 
         public const bool ENABLE_RP_REPORT = false;
-
-        public const string DEFAULT_RP_CONFIG = "{\"$schema\": \"https://raw.githubusercontent.com/reportportal/agent-net-specflow/master/ReportPortal.SpecFlowPlugin/ReportPortal.config.schema\",\"enabled\":true,\"server\":{\"url\":\"\",\"project\":\"\",\"authentication\":{\"uuid\":\"\"}}}";
     }
 }

--- a/src/Molder.ReportPortal/Models/Settings/Interfaces/ISettings.cs
+++ b/src/Molder.ReportPortal/Models/Settings/Interfaces/ISettings.cs
@@ -1,0 +1,9 @@
+﻿namespace Molder.ReportPortal.Models.Settings.Interfaces
+{
+    public interface ISettings
+    {
+        bool IsEnabled();
+        bool CheckServerSettings();
+        bool CheckLaunchSettings();
+    }
+}

--- a/src/Molder.ReportPortal/Models/Settings/ReportPortalSettings.cs
+++ b/src/Molder.ReportPortal/Models/Settings/ReportPortalSettings.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Molder.ReportPortal.Models.Settings
+{
+    [ExcludeFromCodeCoverage]
+    public class ReportPortalSettings
+    {
+        private ReportPortalSettings() { }
+
+        private static Lazy<Settings> _settings = new(() => null);
+        public static Settings Settings
+        {
+            get => _settings.Value;
+            set
+            {
+                _settings = new Lazy<Settings>(() => value);
+            }
+        }
+    }
+}

--- a/src/Molder.ReportPortal/Models/Settings/Settings.cs
+++ b/src/Molder.ReportPortal/Models/Settings/Settings.cs
@@ -1,0 +1,36 @@
+﻿using Molder.ReportPortal.Models.Settings.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace Molder.ReportPortal.Models.Settings
+{
+    public class Settings : ISettings
+    {
+        public bool Enabled { get; set; } = false;
+        public LaunchSettings LaunchSettings { get; set; }
+        public ServerSettings ServerSettings { get; set; }
+
+        public bool IsEnabled() => Enabled;
+        public bool CheckServerSettings() => !String.IsNullOrEmpty(ServerSettings.Project) ||
+            !String.IsNullOrEmpty(ServerSettings.Url) ||
+            !String.IsNullOrEmpty(ServerSettings.Token);
+        public bool CheckLaunchSettings() => !String.IsNullOrEmpty(LaunchSettings.Name);
+    }
+
+    public class LaunchSettings
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool IsRerun { get; set; } = false;
+        public string RerunOfLaunchUuid { get; set; }
+        public DateTime StartTime { get; set; } = DateTime.UtcNow;
+        public List<string> Tags { get; set; }
+    }
+
+    public class ServerSettings
+    {
+        public string Project { get; set; }
+        public string Url { get; set; }
+        public string Token { get; set; }
+    }
+}

--- a/src/Molder.ReportPortal/Molder.ReportPortal.csproj
+++ b/src/Molder.ReportPortal/Molder.ReportPortal.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Molder" Version="2.0.1" />
     <PackageReference Include="ReportPortal.Serilog" Version="2.0.0" />
+    <PackageReference Include="ReportPortal.SpecFlow" Version="3.2.1" />
     <PackageReference Include="SpecFlow" Version="3.9.22" />
   </ItemGroup>
 
@@ -34,6 +35,12 @@
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="ReportPortal.config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   

--- a/src/Molder.ReportPortal/ReportPortal.config.json
+++ b/src/Molder.ReportPortal/ReportPortal.config.json
@@ -1,0 +1,8 @@
+﻿{
+  "enabled": true,
+  "server": {
+    "url": "",
+    "project": "",
+    "authentication": { "uuid": "" }
+  }
+}


### PR DESCRIPTION
в библиотеку Molder.ReportPortal добавлен хук обработки конфигурационных параметров RP  из стандартного appssettings файла проекта (секции Molder.ReportPortal при ее наличии)